### PR TITLE
`None` should return `never` not `null`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ interface SomeInterface extends OptionInterface
 /**
  * @immutable
  *
- * @template TNone of null
+ * @template TNone of never
  *
  * @extends OptionInterface<TNone>
  */

--- a/src/AbstractOption.php
+++ b/src/AbstractOption.php
@@ -7,9 +7,6 @@ namespace Ghostwriter\Option;
 use Generator;
 use Ghostwriter\Option\Exception\NullPointerException;
 use Ghostwriter\Option\Exception\OptionException;
-use Ghostwriter\Option\Tests\Unit\NoneTest;
-use Ghostwriter\Option\Tests\Unit\OptionTest;
-use Ghostwriter\Option\Tests\Unit\SomeTest;
 use Throwable;
 
 /**
@@ -17,9 +14,9 @@ use Throwable;
  *
  * @implements OptionInterface<TOption>
  *
- * @see OptionTest
- * @see SomeTest
- * @see NoneTest
+ * @see \Ghostwriter\Option\Tests\Unit\OptionTest
+ * @see \Ghostwriter\Option\Tests\Unit\SomeTest
+ * @see \Ghostwriter\Option\Tests\Unit\NoneTest
  */
 abstract class AbstractOption implements OptionInterface
 {

--- a/src/None.php
+++ b/src/None.php
@@ -4,16 +4,14 @@ declare(strict_types=1);
 
 namespace Ghostwriter\Option;
 
-use Ghostwriter\Option\Tests\Unit\NoneTest;
-
 /**
- * @template TNone of null
+ * @template TNone of never
  *
  * @extends AbstractOption<TNone>
  *
  * @implements NoneInterface<TNone>
  *
- * @see NoneTest
+ * @see \Ghostwriter\Option\Tests\Unit\NoneTest
  */
 final class None extends AbstractOption implements NoneInterface
 {
@@ -22,6 +20,9 @@ final class None extends AbstractOption implements NoneInterface
     /** @return self<TNone> */
     public static function create(): self
     {
-        return self::$none ??= new self(null);
+        /** @var TNone $none */
+        $none = null;
+
+        return self::$none ??= new self($none);
     }
 }

--- a/src/NoneInterface.php
+++ b/src/NoneInterface.php
@@ -7,7 +7,7 @@ namespace Ghostwriter\Option;
 /**
  * @immutable
  *
- * @template TNone of null
+ * @template TNone of never
  *
  * @extends OptionInterface<TNone>
  */

--- a/src/Option.php
+++ b/src/Option.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Ghostwriter\Option;
 
-/** @see OptionTest */
+/**
+ * @see \Ghostwriter\Option\Tests\Unit\OptionTest
+ */
 final class Option
 {
     /**

--- a/src/Some.php
+++ b/src/Some.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Ghostwriter\Option;
 
 use Ghostwriter\Option\Exception\NullPointerException;
-use Ghostwriter\Option\Tests\Unit\SomeTest;
 
 /**
  * @template TSome
@@ -14,7 +13,7 @@ use Ghostwriter\Option\Tests\Unit\SomeTest;
  *
  * @implements SomeInterface<TSome>
  *
- * @see SomeTest
+ * @see \Ghostwriter\Option\Tests\Unit\SomeTest
  */
 final class Some extends AbstractOption implements SomeInterface
 {

--- a/tests/Unit/NoneTest.php
+++ b/tests/Unit/NoneTest.php
@@ -28,7 +28,9 @@ use Throwable;
 final class NoneTest extends TestCase
 {
     /**
-     * @return Generator<array-key, array{0:class-string,1:mixed}>
+     * @template TNone of null
+     *
+     * @return Generator<array-key, array{0:class-string<NoneInterface>,1:None|TNone}>
      */
     public static function ofDataProvider(): Generator
     {


### PR DESCRIPTION
Thanks to @mathroc findings.

Old Behavior :

```php
<?php

declare(strict_types=1);

interface I {
  /**
   * @param OptionInterface<int> $option
   */
  function f(OptionInterface $option): void;
}

function f(I $i): void {
  $i->f(None::create()); // static analysis type error

  // instead I have to do this
  /** OptionInterface<int> $o */
  $o = None::create();
  $i->f($o);
}
```

New Behavior: 
```php
<?php

declare(strict_types=1);

interface I {
  /**
   * @param OptionInterface<int> $option
   */
  function f(OptionInterface $option): void;
}

function f(I $i): void {
  $i->f(None::create()); // no errors
}
```
