### PR TITLE
Bump `ghostwriter/workbench` from `0.1.x-dev#58471a7` to `0.1.x-dev#9b665a0`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1476,12 +1476,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/workbench.git",
-                "reference": "58471a79ed2cd9fe65ec42c98f66a6fb88aacfee"
+                "reference": "9b665a047e0c2438911297bec5e1f8f17fc3d3fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/workbench/zipball/58471a79ed2cd9fe65ec42c98f66a6fb88aacfee",
-                "reference": "58471a79ed2cd9fe65ec42c98f66a6fb88aacfee",
+                "url": "https://api.github.com/repos/ghostwriter/workbench/zipball/9b665a047e0c2438911297bec5e1f8f17fc3d3fb",
+                "reference": "9b665a047e0c2438911297bec5e1f8f17fc3d3fb",
                 "shasum": ""
             },
             "require": {
@@ -1562,7 +1562,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-01T12:24:17+00:00"
+            "time": "2025-09-02T00:57:41+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Bumps `ghostwriter/workbench` from `0.1.x-dev#58471a7` to `0.1.x-dev#9b665a0`.

This pull request changes the following file(s): 

- Update `composer.lock`