### PR TITLE
Update ghostwriter/coding-standard to version dev-main#62def0c

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,9 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^12.3.12",
-        "symfony/var-dumper": "^7.3.3"
+        "mockery/mockery": "~1.6.12",
+        "phpunit/phpunit": "~12.3.12",
+        "symfony/var-dumper": "~7.3.3"
     },
     "prefer-stable": true,
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55b039ccb07541d2941c8ad8f5f2834c",
+    "content-hash": "023882e88044d021bcef48d8b3265cb6",
     "packages": [],
     "packages-dev": [
         {
@@ -766,12 +766,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225"
+                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/4c9bc3e55140d0c376a3a68f561f7164699e8225",
-                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
+                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
                 "shasum": ""
             },
             "require": {
@@ -928,7 +928,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-21T13:20:26+00:00"
+            "time": "2025-09-21T14:31:25+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#4c9bc3e` to `dev-main#62def0c`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`