### PR TITLE
Update boundwize/structarmed to version 0.7.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.10",
+        "boundwize/structarmed": "^0.7.11",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/testify": "^0.1.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e8ff1978b0c0c30168ff798d34a668a",
+    "content-hash": "a05082b19695fc7df6cd72d35690f07b",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.10",
+            "version": "0.7.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d"
+                "reference": "b8ead2b5fd9a62f9c98bb6d92c440215ca512b47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/35c3929ce13f726ae5384773d7272fc402b0366d",
-                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/b8ead2b5fd9a62f9c98bb6d92c440215ca512b47",
+                "reference": "b8ead2b5fd9a62f9c98bb6d92c440215ca512b47",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.10"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.11"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-25T12:23:38+00:00"
+            "time": "2026-05-25T22:59:15+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -237,16 +237,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "eefd6f57c2aecfe81fe28f1faf3891428da5e776"
+                "reference": "d83e0d58c5b03742f8ee5f9a347281978dfaf4fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/eefd6f57c2aecfe81fe28f1faf3891428da5e776",
-                "reference": "eefd6f57c2aecfe81fe28f1faf3891428da5e776",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/d83e0d58c5b03742f8ee5f9a347281978dfaf4fe",
+                "reference": "d83e0d58c5b03742f8ee5f9a347281978dfaf4fe",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.10",
+                "boundwize/structarmed": "^0.7.11",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -294,7 +294,7 @@
                 "ext-zlib": "*",
                 "mockery/mockery": "^1.6.12",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^13.1.11",
+                "phpunit/phpunit": "^13.1.12",
                 "symfony/var-dumper": "^8.0.8"
             },
             "conflict": {
@@ -357,7 +357,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-25T15:06:57+00:00"
+            "time": "2026-05-26T00:11:34+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.10` to `0.7.11`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`