### PR TITLE
Update ghostwriter/testify to version 0.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "ext-xdebug": "*",
         "boundwize/structarmed": "^0.7.12",
         "ghostwriter/coding-standard": "dev-main",
-        "ghostwriter/testify": "^0.1.1",
+        "ghostwriter/testify": "^0.1.2",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.12",
         "symfony/var-dumper": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e150c8482df4138c17863fdb799f55e3",
+    "content-hash": "c7a427a97a79227ab443462e98f3d88d",
     "packages": [],
     "packages-dev": [
         {
@@ -754,16 +754,16 @@
         },
         {
             "name": "ghostwriter/testify",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/testify.git",
-                "reference": "bafc11a8a5d83e4de796e83b5c206b9fb4b72609"
+                "reference": "178499d1483b48124703ae76d304370be21dcf8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/testify/zipball/bafc11a8a5d83e4de796e83b5c206b9fb4b72609",
-                "reference": "bafc11a8a5d83e4de796e83b5c206b9fb4b72609",
+                "url": "https://api.github.com/repos/ghostwriter/testify/zipball/178499d1483b48124703ae76d304370be21dcf8b",
+                "reference": "178499d1483b48124703ae76d304370be21dcf8b",
                 "shasum": ""
             },
             "require": {
@@ -771,17 +771,18 @@
                 "ghostwriter/case-converter": "^2.2.2",
                 "ghostwriter/config": "^2.1.3",
                 "ghostwriter/console": "^0.2.3",
-                "ghostwriter/container": "^7.0.1",
+                "ghostwriter/container": "^7.0.2",
                 "ghostwriter/event-dispatcher": "^6.1.1",
                 "ghostwriter/filesystem": "^0.2.0",
                 "nikic/php-parser": "^5.7.0",
                 "php": "~8.4.0 || ~8.5.0"
             },
             "require-dev": {
+                "boundwize/structarmed": "^0.7.12",
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^13.1.8",
+                "phpunit/phpunit": "^13.1.12",
                 "symfony/var-dumper": "^8.0.8"
             },
             "bin": [
@@ -838,7 +839,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-07T03:08:20+00:00"
+            "time": "2026-05-27T08:34:49+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/testify` dependency from `0.1.1` to `0.1.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`