### PR TITLE
Update `boundwize/structarmed` to version `0.11.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.10.1",
+        "boundwize/structarmed": "^0.11.0",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e7a0e2f8e25186042f4c9745097bf1f",
+    "content-hash": "9a46ccc19a4bf826f342db3419c62f4e",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.10.1",
+            "version": "0.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "7c9b0b47f7e5c715457be498c22476120df4ab84"
+                "reference": "a12b7107c9b3b85da43f3416c477ca3e64e9d008"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/7c9b0b47f7e5c715457be498c22476120df4ab84",
-                "reference": "7c9b0b47f7e5c715457be498c22476120df4ab84",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/a12b7107c9b3b85da43f3416c477ca3e64e9d008",
+                "reference": "a12b7107c9b3b85da43f3416c477ca3e64e9d008",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.10.1"
+                "source": "https://github.com/boundwize/structarmed/tree/0.11.0"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-02T13:40:20+00:00"
+            "time": "2026-06-03T09:39:13+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.10.1` to `0.11.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`